### PR TITLE
docs: Use TLA

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ npm install age-encryption
 ```ts
 import age from "age-encryption"
 
-await (async() => {
+{
     const { Encrypter, Decrypter, generateIdentity, identityToRecipient } = await age()
 
     const identity = await generateIdentity()
@@ -42,9 +42,9 @@ await (async() => {
     const out = await d.decrypt(ciphertext, "text")
 
     console.log(out)
-})()
+}
 
-await (async() => {
+{
     const { Encrypter, Decrypter } = await age()
 
     const e = new Encrypter()
@@ -56,5 +56,5 @@ await (async() => {
     const out = await d.decrypt(ciphertext, "text")
 
     console.log(out)
-})()
+}
 ```


### PR DESCRIPTION
Top Level Await was activated by default (not behind a flag) since [Node v14.8](https://www.stefanjudis.com/today-i-learned/top-level-await-is-available-in-node-js-modules/#top-level-%60await%60-is-available-%22unflagged%22-in-node.js-since-%60v14.8%60). Node v14 is [no longer maintained](https://endoflife.date/nodejs), so we can remove the IIFE ceremony of `(async () => {})()` and just use `await` directly.

I replaced the IIFE with a compound statement block since it seemed it was intended to have the codes separated in some way.