### PR TITLE
chore: add property tests for encryption/decryption

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
                 "libsodium-wrappers-sumo": "^0.7.11"
             },
             "devDependencies": {
+                "@fast-check/vitest": "^0.0.6",
                 "@types/libsodium-wrappers-sumo": "^0.7.5",
                 "@types/node": "^20.4.8",
                 "@typescript-eslint/eslint-plugin": "^6.1.0",
@@ -437,6 +438,28 @@
             "dev": true,
             "engines": {
                 "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+            }
+        },
+        "node_modules/@fast-check/vitest": {
+            "version": "0.0.6",
+            "resolved": "https://registry.npmjs.org/@fast-check/vitest/-/vitest-0.0.6.tgz",
+            "integrity": "sha512-fcns/2fvWopeUt7hdPcDgPxasekAJhXpdxtu9n+g5kPB/S60+V0onuQirwFqRKg2g3Z7hkrQJkkHOM1MaMGdDA==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "individual",
+                    "url": "https://github.com/sponsors/dubzzz"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/fast-check"
+                }
+            ],
+            "dependencies": {
+                "fast-check": "^3.0.0"
+            },
+            "peerDependencies": {
+                "vitest": ">=0.28.1"
             }
         },
         "node_modules/@humanwhocodes/config-array": {
@@ -1351,6 +1374,28 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/fast-check": {
+            "version": "3.12.0",
+            "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-3.12.0.tgz",
+            "integrity": "sha512-SqahE9mlL3+lhjJ39joMLwcj6F+24hfZdf/tchlNO8sHcTdrUUdA5P/ZbSFZM9Xpzs36XaneGwE0FWepm/zyOA==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "individual",
+                    "url": "https://github.com/sponsors/dubzzz"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/fast-check"
+                }
+            ],
+            "dependencies": {
+                "pure-rand": "^6.0.0"
+            },
+            "engines": {
+                "node": ">=8.0.0"
+            }
+        },
         "node_modules/fast-deep-equal": {
             "version": "3.1.3",
             "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -2094,6 +2139,22 @@
             "engines": {
                 "node": ">=6"
             }
+        },
+        "node_modules/pure-rand": {
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-6.0.2.tgz",
+            "integrity": "sha512-6Yg0ekpKICSjPswYOuC5sku/TSWaRYlA0qsXqJgM/d/4pLPHPuTxK7Nbf7jFKzAeedUhR8C7K9Uv63FBsSo8xQ==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "individual",
+                    "url": "https://github.com/sponsors/dubzzz"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/fast-check"
+                }
+            ]
         },
         "node_modules/queue-microtask": {
             "version": "1.2.3",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
         "prepublishOnly": "npm run build"
     },
     "devDependencies": {
+        "@fast-check/vitest": "^0.0.6",
         "@types/libsodium-wrappers-sumo": "^0.7.5",
         "@types/node": "^20.4.8",
         "@typescript-eslint/eslint-plugin": "^6.1.0",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     ],
     "repository": "github:FiloSottile/age.ts",
     "type": "module",
+    "types": "./dist/index.d.ts",
     "keywords": [
         "age",
         "file encryption",

--- a/tests/property.test.ts
+++ b/tests/property.test.ts
@@ -1,7 +1,6 @@
 import { describe } from 'vitest'
 import { test, fc } from '@fast-check/vitest'
 import age from '../lib/index.js'
-import { to_string } from 'libsodium-wrappers-sumo'
 
 fc.configureGlobal({
   // increasing this value will make fast-check do more random test runs,
@@ -43,7 +42,7 @@ describe('Property Based Tests', () => {
         enc.addRecipient(recipient)
         dec.addIdentity(identity)
 
-        return to_string(dec.decrypt(enc.encrypt(plaintext))) === plaintext
+        return dec.decrypt(enc.encrypt(plaintext), 'text') === plaintext
       }
     )
 
@@ -89,7 +88,7 @@ describe('Property Based Tests', () => {
         enc.setPassphrase(passphrase)
         dec.addPassphrase(passphrase)
 
-        return to_string(dec.decrypt(enc.encrypt(plaintext))) === plaintext
+        return dec.decrypt(enc.encrypt(plaintext), 'text') === plaintext
       }
     )
 

--- a/tests/property.test.ts
+++ b/tests/property.test.ts
@@ -1,0 +1,117 @@
+import { describe } from 'vitest'
+import { test, fc } from '@fast-check/vitest'
+import age from '../lib/index.js'
+import { to_string } from 'libsodium-wrappers-sumo'
+
+fc.configureGlobal({
+  // increasing this value will make fast-check do more random test runs,
+  // which might be good for intensive testing, but also makes them slower.
+  numRuns: 50
+})
+
+const isEqualUInt8Array = (a: Uint8Array, b: Uint8Array) => {
+  if (a.length !== a.length) {
+    return false
+  }
+
+  for (let i = 0; i < a.byteLength; i++) {
+    if (a[i] !== b[i]) {
+      return false
+    }
+  }
+
+  return true
+}
+
+describe('Property Based Tests', () => {
+  describe('Asymmetric Encryption and Decryption', () => {
+    test.prop(
+      {
+        plaintext: fc.string()
+      }
+    )(
+      'decryption should invert encryption with identity/recipient (string plaintext)',
+      async ({ plaintext }) => {
+        const { Decrypter, Encrypter, generateIdentity, identityToRecipient } = await age()
+
+        const identity = generateIdentity()
+        const recipient = identityToRecipient(identity)
+
+        const enc = new Encrypter()
+        const dec = new Decrypter()
+
+        enc.addRecipient(recipient)
+        dec.addIdentity(identity)
+
+        return to_string(dec.decrypt(enc.encrypt(plaintext))) === plaintext
+      }
+    )
+
+    test.prop(
+      {
+        plaintext: fc.uint8Array()
+      }
+    )(
+      'decryption should invert encryption with identity/recipient (uint8array plaintext)',
+      async ({ plaintext }) => {
+        const { Decrypter, Encrypter, generateIdentity, identityToRecipient } = await age()
+
+        const identity = generateIdentity()
+        const recipient = identityToRecipient(identity)
+
+        const enc = new Encrypter()
+        const dec = new Decrypter()
+
+        enc.addRecipient(recipient)
+        dec.addIdentity(identity)
+
+        return isEqualUInt8Array(dec.decrypt(enc.encrypt(plaintext)), plaintext)
+      }
+    )
+  })
+
+
+  describe('Symmetric Encryption and Decryption', () => {
+    test.prop(
+      {
+        plaintext: fc.string(),
+        passphrase: fc.string(),
+        scryptWorkFactor: fc.integer({ min: 1, max: 12 })
+      }
+    )(
+      'decryption should invert encryption with passphrase (string plaintext)',
+      async ({ plaintext, passphrase, scryptWorkFactor }) => {
+        const { Decrypter, Encrypter } = await age()
+        const enc = new Encrypter()
+        const dec = new Decrypter()
+
+        enc.setScryptWorkFactor(scryptWorkFactor)
+        enc.setPassphrase(passphrase)
+        dec.addPassphrase(passphrase)
+
+        return to_string(dec.decrypt(enc.encrypt(plaintext))) === plaintext
+      }
+    )
+
+    test.prop(
+      {
+        plaintext: fc.uint8Array(),
+        passphrase: fc.string(),
+        scryptWorkFactor: fc.integer({ min: 1, max: 12 })
+      }
+    )(
+      'decryption should invert encryption with passphrase (UInt8Array plaintext)',
+      async ({ plaintext, passphrase, scryptWorkFactor }) => {
+        const { Decrypter, Encrypter } = await age()
+        const enc = new Encrypter()
+        const dec = new Decrypter()
+
+        enc.setScryptWorkFactor(scryptWorkFactor)
+        enc.setPassphrase(passphrase)
+        dec.addPassphrase(passphrase)
+
+        return isEqualUInt8Array(dec.decrypt(enc.encrypt(plaintext)), plaintext)
+      }
+    )
+  })
+})

--- a/tests/property.test.ts
+++ b/tests/property.test.ts
@@ -75,7 +75,7 @@ describe('Property Based Tests', () => {
       {
         plaintext: fc.string(),
         passphrase: fc.string(),
-        scryptWorkFactor: fc.integer({ min: 1, max: 12 })
+        scryptWorkFactor: fc.integer({ min: 1, max: 4 })
       }
     )(
       'decryption should invert encryption with passphrase (string plaintext)',

--- a/tests/property.test.ts
+++ b/tests/property.test.ts
@@ -96,7 +96,7 @@ describe('Property Based Tests', () => {
       {
         plaintext: fc.uint8Array(),
         passphrase: fc.string(),
-        scryptWorkFactor: fc.integer({ min: 1, max: 12 })
+        scryptWorkFactor: fc.integer({ min: 1, max: 4 })
       }
     )(
       'decryption should invert encryption with passphrase (UInt8Array plaintext)',

--- a/tests/property.test.ts
+++ b/tests/property.test.ts
@@ -10,7 +10,7 @@ fc.configureGlobal({
 })
 
 const isEqualUInt8Array = (a: Uint8Array, b: Uint8Array) => {
-  if (a.length !== a.length) {
+  if (a.byteLength !== a.byteLength) {
     return false
   }
 


### PR DESCRIPTION
Hi, I created some basic property based tests using [fast-check](https://github.com/dubzzz/fast-check) in case that's helpful for this project. The tests run a bit longer than the regular unit tests since they do multiple iterations with random data. With the current setting of 50 runs per property it takes ca. 1000ms on my machine. I think the scrypt factor adds the most delay, so I could also change it to use a slower number for these tests. Happy to make more contributions if there's something to do and I find the time.