### PR TITLE
Support for use in browser

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ All low-level cryptographic operations are implemented with [libsodium.js](https
 npm install age-encryption
 ```
 
-## Usage
+## Usage (Node)
 
 ```ts
 import age from "age-encryption"
@@ -55,3 +55,13 @@ d.addPassphrase("burst-swarm-slender-curve-ability-various-crystal-moon-affair-t
 const out = d.decrypt(ciphertext, "text")
 console.log(out)
 ```
+
+## Usage (Browser)
+
+The library can be bundled with esbuild and used in a browser.  
+To bundle, run the bundle command in the package.json:  
+```
+npm run bundle
+```
+This will generate a bundle.js file under dist.  
+Just include bundle.js and have fun! Please look at examples/browser.html for an example.

--- a/examples/browser.html
+++ b/examples/browser.html
@@ -1,0 +1,24 @@
+<html>
+
+<body>
+    <script src="../dist/bundle.js"></script>
+    <script type="module">
+        const { Encrypter, Decrypter, generateIdentity, identityToRecipient } = await ageModule.default()
+
+        const identity = generateIdentity()
+        const recipient = identityToRecipient(identity)
+        console.log(identity)
+        console.log(recipient)
+
+        const e = new Encrypter()
+        e.addRecipient(recipient)
+        const ciphertext = e.encrypt("Hello, age!")
+
+        const d = new Decrypter()
+        d.addIdentity(identity)
+        const out = d.decrypt(ciphertext, "text")
+        console.log(out)
+    </script>
+</body>
+
+</html>

--- a/lib/hkdf.ts
+++ b/lib/hkdf.ts
@@ -1,11 +1,13 @@
-import * as sodium from "libsodium-wrappers-sumo"
+import _sodium from "libsodium-wrappers-sumo"
 import { from_string } from "libsodium-wrappers-sumo"
+
+const sodium = _sodium
 
 // @types/libsodium-wrappers-sumo is missing these definitions.
 declare module "libsodium-wrappers-sumo" {
-    export function crypto_auth_hmacsha256_init(key: Uint8Array): sodium.StateAddress;
-    export function crypto_auth_hmacsha256_update(stateAddress: sodium.StateAddress, messageChunk: Uint8Array): void;
-    export function crypto_auth_hmacsha256_final(stateAddress: sodium.StateAddress): Uint8Array;
+    export function crypto_auth_hmacsha256_init(key: Uint8Array): _sodium.StateAddress;
+    export function crypto_auth_hmacsha256_update(stateAddress: _sodium.StateAddress, messageChunk: Uint8Array): void;
+    export function crypto_auth_hmacsha256_final(stateAddress: _sodium.StateAddress): Uint8Array;
 }
 
 // HKDF extracts 32 bytes from HKDF-SHA-256 with the specified input key material, salt, and info.

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,4 +1,4 @@
-import * as sodium from "libsodium-wrappers-sumo"
+import _sodium from "libsodium-wrappers-sumo"
 import { from_string, to_string } from "libsodium-wrappers-sumo"
 import { decode as decodeBech32, encode as encodeBech32 } from "bech32-buffer"
 import { scryptUnwrap, scryptWrap, x25519Identity, x25519Unwrap, x25519Wrap } from "./recipients.js"
@@ -14,6 +14,7 @@ interface age {
 }
 
 let initDone = false
+let sodium = _sodium
 
 export default async function init(): Promise<age> {
   if (!initDone) {

--- a/lib/recipients.ts
+++ b/lib/recipients.ts
@@ -1,6 +1,8 @@
-import * as sodium from "libsodium-wrappers-sumo"
+import _sodium from "libsodium-wrappers-sumo"
 import { decodeBase64, encodeBase64, Stanza } from "./format.js"
 import { HKDF } from "./hkdf.js"
+
+const sodium = _sodium
 
 export interface x25519Identity {
     identity: Uint8Array, recipient: Uint8Array,

--- a/lib/stream.ts
+++ b/lib/stream.ts
@@ -1,4 +1,6 @@
-import * as sodium from "libsodium-wrappers-sumo"
+import _sodium from "libsodium-wrappers-sumo"
+
+const sodium = _sodium
 
 // We can't use sodium.crypto_aead_chacha20poly1305_IETF_ABYTES here before
 // sodium.ready, or it will make the constant be silently NaN, and nothing will

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
         "lint": "eslint .",
         "build": "tsc -p tsconfig.build.json",
         "prepublishOnly": "npm run build",
-        "bundle": "esbuild dist/index.js --bundle --outfile=dist/bundle.js --global-name=ageModule"
+        "bundle": "esbuild lib/index.ts --bundle --minify --tsconfig=tsconfig.build.json --outfile=dist/bundle.js --global-name=ageModule"
     },
     "devDependencies": {
         "@fast-check/vitest": "^0.0.6",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
         "test": "vitest --run",
         "lint": "eslint .",
         "build": "tsc -p tsconfig.build.json",
-        "prepublishOnly": "npm run build"
+        "prepublishOnly": "npm run build",
+        "bundle": "esbuild dist/index.js --bundle --outfile=dist/bundle.js --global-name=ageModule"
     },
     "devDependencies": {
         "@fast-check/vitest": "^0.0.6",


### PR DESCRIPTION
This pull request is for solving #7.

By changing the import statements, the tests still pass and libsodium also is bundled correctly with esbundle, and the entire age.ts becomes usable inside the browser.
I have seen the `_sodium` import somewhere on StackOverflow, maybe there is a better way to do it, but this works.
I also included building instructions and a minimal example.