### PR TITLE
Compability changes

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,0 +1,28 @@
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [
+          18.x, # LTS as of 2023-11
+          20.x  # current as of 2023-11
+        ]
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+      - uses: oven-sh/setup-bun@v1
+        with:
+          bun-version: latest
+      - run: npm install
+      - run: npm run build
+      - run: npm run test
+      - run: npm run examples

--- a/lib/format.ts
+++ b/lib/format.ts
@@ -1,7 +1,7 @@
-import { base64_variants, from_base64, from_string, to_base64, to_string } from "libsodium-wrappers-sumo"
+import { sodium } from "./sodium.js";
 
-export const decodeBase64 = (s: string) => from_base64(s, base64_variants.ORIGINAL_NO_PADDING)
-export const encodeBase64 = (s: Uint8Array) => to_base64(s, base64_variants.ORIGINAL_NO_PADDING)
+export const decodeBase64 = (s: string) => sodium.from_base64(s, sodium.base64_variants.ORIGINAL_NO_PADDING)
+export const encodeBase64 = (s: Uint8Array) => sodium.to_base64(s, sodium.base64_variants.ORIGINAL_NO_PADDING)
 
 export class Stanza {
     readonly args: string[]
@@ -25,7 +25,7 @@ class ByteReader {
                 throw Error("invalid non-ASCII byte in header")
             }
         })
-        return to_string(bytes)
+        return sodium.to_string(bytes)
     }
 
     readString(n: number): string {
@@ -150,12 +150,12 @@ export function encodeHeaderNoMAC(recipients: Stanza[]): Uint8Array {
     }
 
     lines.push("---")
-    return from_string(lines.join(""))
+    return sodium.from_string(lines.join(""))
 }
 
 export function encodeHeader(recipients: Stanza[], MAC: Uint8Array): Uint8Array {
     return flattenArray([
         encodeHeaderNoMAC(recipients),
-        from_string(" " + encodeBase64(MAC) + "\n")
+        sodium.from_string(" " + encodeBase64(MAC) + "\n")
     ])
 }

--- a/lib/hkdf.ts
+++ b/lib/hkdf.ts
@@ -1,5 +1,4 @@
-import * as sodium from "libsodium-wrappers-sumo"
-import { from_string } from "libsodium-wrappers-sumo"
+import { sodium } from "./sodium.js";
 
 // @types/libsodium-wrappers-sumo is missing these definitions.
 declare module "libsodium-wrappers-sumo" {
@@ -17,7 +16,7 @@ export function HKDF(ikm: Uint8Array, salt: Uint8Array | null, info: string): Ui
     const prk = sodium.crypto_auth_hmacsha256_final(h)
 
     const infoAndCounter = new Uint8Array(info.length + 1)
-    infoAndCounter.set(from_string(info))
+    infoAndCounter.set(sodium.from_string(info))
     infoAndCounter[info.length] = 1
 
     return sodium.crypto_auth_hmacsha256(infoAndCounter, prk)

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,5 +1,4 @@
-import * as sodium from "libsodium-wrappers-sumo"
-import { from_string, to_string } from "libsodium-wrappers-sumo"
+import { sodium } from "./sodium.js";
 import { decode as decodeBech32, encode as encodeBech32 } from "bech32-buffer"
 import { scryptUnwrap, scryptWrap, x25519Identity, x25519Unwrap, x25519Wrap } from "./recipients.js"
 import { encodeHeader, encodeHeaderNoMAC, parseHeader, Stanza } from "./format.js"
@@ -74,7 +73,7 @@ class Encrypter {
 
   encrypt(file: Uint8Array | string): Uint8Array {
     if (typeof file === "string") {
-      file = from_string(file)
+      file = sodium.from_string(file)
     }
 
     const fileKey = sodium.randombytes_buf(16)
@@ -142,7 +141,7 @@ class Decrypter {
     const payload = h.rest.subarray(16)
 
     const out = decryptSTREAM(streamKey, payload)
-    if (outputFormat === "text") return to_string(out)
+    if (outputFormat === "text") return sodium.to_string(out)
     return out
   }
 

--- a/lib/recipients.ts
+++ b/lib/recipients.ts
@@ -1,4 +1,4 @@
-import * as sodium from "libsodium-wrappers-sumo"
+import { sodium } from "./sodium.js";
 import { decodeBase64, encodeBase64, Stanza } from "./format.js"
 import { HKDF } from "./hkdf.js"
 

--- a/lib/sodium.ts
+++ b/lib/sodium.ts
@@ -1,0 +1,2 @@
+// Export a single `sodium` object to be used throughout the project, to avoid issues with import semantics.
+export { default as sodium } from "libsodium-wrappers-sumo"

--- a/lib/stream.ts
+++ b/lib/stream.ts
@@ -1,4 +1,4 @@
-import * as sodium from "libsodium-wrappers-sumo"
+import { sodium } from "./sodium.js";
 
 // We can't use sodium.crypto_aead_chacha20poly1305_IETF_ABYTES here before
 // sodium.ready, or it will make the constant be silently NaN, and nothing will

--- a/package.json
+++ b/package.json
@@ -19,9 +19,11 @@
     },
     "scripts": {
         "test": "vitest --run",
+        "examples": "bun run tests/readme-examples/passphrase.ts && bun run tests/readme-examples/recipient.ts",
         "lint": "eslint .",
         "build": "tsc -p tsconfig.build.json",
-        "prepublishOnly": "npm run build"
+        "prepublishOnly": "npm run build",
+        "clean": "rm -rf ./dist"
     },
     "devDependencies": {
         "@fast-check/vitest": "^0.0.6",

--- a/tests/format.test.ts
+++ b/tests/format.test.ts
@@ -1,7 +1,9 @@
 import { strict as assert } from 'assert'
 import { describe, it } from 'vitest'
-import { from_string, to_string } from 'libsodium-wrappers-sumo'
+import { sodium } from '../lib/sodium.js'
 import { decodeBase64, encodeHeader, encodeHeaderNoMAC, parseHeader } from '../lib/format.js'
+
+await sodium.ready
 
 const exampleHeader = `age-encryption.org/v1
 -> X25519 abc
@@ -11,27 +13,27 @@ this is the payload`
 
 describe('parseHeader', () => {
     it('should parse a well formatted header', () => {
-        const h = parseHeader(from_string(exampleHeader))
+        const h = parseHeader(sodium.from_string(exampleHeader))
         assert.equal(h.recipients.length, 1)
         assert.deepEqual(h.recipients[0].args, ["X25519", "abc"])
         assert.deepEqual(h.recipients[0].body, decodeBase64("0OrTkKHpE7klNLd0k+9Uam5hkQkzMxaqKcIPRIO1sNE"))
         assert.deepEqual(h.MAC, decodeBase64("gxhoSa5BciRDt8lOpYNcx4EYtKpS0CJ06F3ZwN82VaM"))
-        assert.deepEqual(h.rest, from_string("this is the payload"))
+        assert.deepEqual(h.rest, sodium.from_string("this is the payload"))
     })
     it('should reencode to the original header', () => {
-        const h = parseHeader(from_string(exampleHeader))
+        const h = parseHeader(sodium.from_string(exampleHeader))
         assert.deepEqual(encodeHeaderNoMAC(h.recipients), h.headerNoMAC)
-        const got = to_string(encodeHeader(h.recipients, h.MAC)) + to_string(h.rest)
+        const got = sodium.to_string(encodeHeader(h.recipients, h.MAC)) + sodium.to_string(h.rest)
         assert.deepEqual(got, exampleHeader)
     })
 })
 
 describe('decodeBase64', () => {
     it('should parse a valid base64 string', () => {
-        assert.deepEqual(decodeBase64("dGVzdA"), from_string("test"))
+        assert.deepEqual(decodeBase64("dGVzdA"), sodium.from_string("test"))
     })
     it('should parse a valid base64 string with spare bits', () => {
-        assert.deepEqual(decodeBase64("dGVzdDI"), from_string("test2"))
+        assert.deepEqual(decodeBase64("dGVzdDI"), sodium.from_string("test2"))
     })
     it('should reject a non-canonical base64 string', () => {
         assert.throws(() => { decodeBase64("dGVzdDJ") })

--- a/tests/hkdf.test.ts
+++ b/tests/hkdf.test.ts
@@ -1,18 +1,20 @@
 import { describe, it, assert } from 'vitest'
-import { from_string, to_hex } from 'libsodium-wrappers-sumo'
+import { sodium } from '../lib/sodium.js'
 import { HKDF } from '../lib/hkdf.js'
+
+await sodium.ready
 
 describe('HKDF', () => {
     it('should generate the right value for secret/salt/info', () => {
-        const h = HKDF(from_string("secret"), from_string("saltsaltsaltsaltsaltsaltsaltsalt"), "info")
-        assert.equal(to_hex(h), "b3bae2c60b0fffa7c7eb7af6560f6419b027feb579f42674c7b6ef6fbca64d7d")
+        const h = HKDF(sodium.from_string("secret"), sodium.from_string("saltsaltsaltsaltsaltsaltsaltsalt"), "info")
+        assert.equal(sodium.to_hex(h), "b3bae2c60b0fffa7c7eb7af6560f6419b027feb579f42674c7b6ef6fbca64d7d")
     })
     it('should generate the right value for short salt', () => {
-        const h = HKDF(from_string("secret"), from_string("salt"), "info")
-        assert.equal(to_hex(h), "f6d2fcc47cb939deafe3853a1e641a27e6924aff7a63d09cb04ccfffbe4776ef")
+        const h = HKDF(sodium.from_string("secret"), sodium.from_string("salt"), "info")
+        assert.equal(sodium.to_hex(h), "f6d2fcc47cb939deafe3853a1e641a27e6924aff7a63d09cb04ccfffbe4776ef")
     })
     it('should generate the right value for null salt', () => {
-        const h = HKDF(from_string("secret"), null, "info")
-        assert.equal(to_hex(h), "7e11a191fa879919dcf4e336e0d736091bee42c78d4ccb86214290a677884a7a")
+        const h = HKDF(sodium.from_string("secret"), null, "info")
+        assert.equal(sodium.to_hex(h), "7e11a191fa879919dcf4e336e0d736091bee42c78d4ccb86214290a677884a7a")
     })
 })

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -1,8 +1,10 @@
 import { describe, it, assert } from 'vitest'
-import { base64_variants, from_base64, to_string } from "libsodium-wrappers-sumo"
+import { sodium } from '../lib/sodium.js'
 import age from "../lib/index.js"
 
-const fromBase64 = (s: string) => from_base64(s, base64_variants.ORIGINAL_NO_PADDING)
+await sodium.ready
+
+const fromBase64 = (s: string) => sodium.from_base64(s, sodium.base64_variants.ORIGINAL_NO_PADDING)
 
 describe('AgeDecrypter', function () {
     it('should decrypt a file with the right passphrase', async function () {
@@ -51,7 +53,7 @@ describe('AgeEncrypter', function () {
         d.addPassphrase("light-original-energy-average-wish-blind-vendor-pencil-illness-scorpion")
         const out = d.decrypt(file)
 
-        assert.deepEqual(to_string(out), "age")
+        assert.deepEqual(sodium.to_string(out), "age")
     })
     it('should encrypt (and decrypt) a file with a recipient', async function () {
         const { Decrypter, Encrypter } = await age()
@@ -63,7 +65,7 @@ describe('AgeEncrypter', function () {
         d.addIdentity("AGE-SECRET-KEY-1RKH0DGHQ0FU6VLXX2VW6Y3W2TKK7KR4J36N9SNDXK75JHCJ3N6JQNZJF5J")
         const out = d.decrypt(file)
 
-        assert.deepEqual(to_string(out), "age")
+        assert.deepEqual(sodium.to_string(out), "age")
     })
     it('should encrypt (and decrypt) a file with multiple recipients', async function () {
         const { Decrypter, Encrypter } = await age()
@@ -76,7 +78,7 @@ describe('AgeEncrypter', function () {
         d.addIdentity("AGE-SECRET-KEY-1RKH0DGHQ0FU6VLXX2VW6Y3W2TKK7KR4J36N9SNDXK75JHCJ3N6JQNZJF5J")
         const out = d.decrypt(file)
 
-        assert.deepEqual(to_string(out), "age")
+        assert.deepEqual(sodium.to_string(out), "age")
     })
     it('should throw when using multiple passphrases', async function () {
         const { Encrypter } = await age()

--- a/tests/readme-examples/passphrase.ts
+++ b/tests/readme-examples/passphrase.ts
@@ -1,0 +1,18 @@
+#!/usr/bin/env bun
+
+import age from "../../lib/index.js";
+
+// Initialize the library (calls sodium.ready).
+
+const { Encrypter, Decrypter, generateIdentity, identityToRecipient } = await age()
+
+// Encrypt and decrypt a file with a passphrase.
+
+const e = new Encrypter()
+e.setPassphrase("burst-swarm-slender-curve-ability-various-crystal-moon-affair-three")
+const ciphertext = e.encrypt("Hello, age!")
+
+const d = new Decrypter()
+d.addPassphrase("burst-swarm-slender-curve-ability-various-crystal-moon-affair-three")
+const out = d.decrypt(ciphertext, "text")
+console.log(out)

--- a/tests/readme-examples/recipient.ts
+++ b/tests/readme-examples/recipient.ts
@@ -1,0 +1,23 @@
+#!/usr/bin/env bun
+
+import age from "../../lib/index.js";
+
+// Initialize the library (calls sodium.ready).
+
+const { Encrypter, Decrypter, generateIdentity, identityToRecipient } = await age()
+
+// Encrypt and decrypt a file with a new recipient / identity pair.
+
+const identity = generateIdentity()
+const recipient = identityToRecipient(identity)
+console.log(identity)
+console.log(recipient)
+
+const e = new Encrypter()
+e.addRecipient(recipient)
+const ciphertext = e.encrypt("Hello, age!")
+
+const d = new Decrypter()
+d.addIdentity(identity)
+const out = d.decrypt(ciphertext, "text")
+console.log(out)

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,5 +4,9 @@
         "esModuleInterop": true,
         "target": "ES6",
         "moduleResolution": "nodenext",
+        "module": "nodenext"
     },
+    "include": [
+        "lib"
+    ]
 }


### PR DESCRIPTION
- Import the `sodium` object in a single place and use the object across the project. This simplifies the import semantics and enables compatibility with `node` and `bun`: https://github.com/FiloSottile/age.ts/issues/9
- Configure CI to run using GitHub Actions.
- Add the examples from the README to `tests/readme-examples` and test them in CI using `bun`.
- Add `npm run clean`
- Update `tsconfig.json` to avoid warnings:
  - Set `"module": "nodenext"` to avoid: "Option 'module' must be set to 'NodeNext' when option 'moduleResolution' is set to 'NodeNext'.ts" (from TypeScript).
  - Set the `"include"` to the `"lib"` folder so that the top-level await lines in `tests/readme-examples` don't show errors.