### PR TITLE
Split the README examples into blocks so the full code sample is valid.

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,30 +28,34 @@ import age from "age-encryption"
 
 const { Encrypter, Decrypter, generateIdentity, identityToRecipient } = await age()
 
-// Encrypt and decrypt a file with a new recipient / identity pair.
+{
+    // Encrypt and decrypt a file with a new recipient / identity pair.
 
-const identity = generateIdentity()
-const recipient = identityToRecipient(identity)
-console.log(identity)
-console.log(recipient)
+    const identity = generateIdentity()
+    const recipient = identityToRecipient(identity)
+    console.log(identity)
+    console.log(recipient)
 
-const e = new Encrypter()
-e.addRecipient(recipient)
-const ciphertext = e.encrypt("Hello, age!")
+    const e = new Encrypter()
+    e.addRecipient(recipient)
+    const ciphertext = e.encrypt("Hello, age!")
 
-const d = new Decrypter()
-d.addIdentity(identity)
-const out = d.decrypt(ciphertext, "text")
-console.log(out)
+    const d = new Decrypter()
+    d.addIdentity(identity)
+    const out = d.decrypt(ciphertext, "text")
+    console.log(out)
+}
 
-// Encrypt and decrypt a file with a passphrase.
+{
+    // Encrypt and decrypt a file with a passphrase.
 
-const e = new Encrypter()
-e.setPassphrase("burst-swarm-slender-curve-ability-various-crystal-moon-affair-three")
-const ciphertext = e.encrypt("Hello, age!")
+    const e = new Encrypter()
+    e.setPassphrase("burst-swarm-slender-curve-ability-various-crystal-moon-affair-three")
+    const ciphertext = e.encrypt("Hello, age!")
 
-const d = new Decrypter()
-d.addPassphrase("burst-swarm-slender-curve-ability-various-crystal-moon-affair-three")
-const out = d.decrypt(ciphertext, "text")
-console.log(out)
+    const d = new Decrypter()
+    d.addPassphrase("burst-swarm-slender-curve-ability-various-crystal-moon-affair-three")
+    const out = d.decrypt(ciphertext, "text")
+    console.log(out)
+}
 ```


### PR DESCRIPTION
The previous version re-declared `const` variable. If you copied the entire sample code (e.g. using the copy button that GitHub adds to the upper right of the code block) into a file, you would get TypeScript errors and runtime errors.

By wrapping each example in a [block statement](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/block), we avoid the `const` conflicts so that both snippets can live in the same source.